### PR TITLE
Clear feedback when not in meeting

### DIFF
--- a/zoom-osc.js
+++ b/zoom-osc.js
@@ -961,6 +961,7 @@ instance.prototype.init_feedbacks = function(){
 			//handle feedback code
 			callback: (feedback,bank)=>{
 
+				if(!self.zoomosc_client_data.callStatus) return;
 				var opts=feedback.options;
 				//only attempt the feedback if user and property exists
 				if(opts.user!=undefined&& opts.prop!=undefined){


### PR DESCRIPTION
Variables are already cleared, so I think feedback should be cleared for consistancy.